### PR TITLE
test: add case(string).

### DIFF
--- a/test/amf-deserialized.spec.ts
+++ b/test/amf-deserialized.spec.ts
@@ -15,3 +15,29 @@ test("Deserialize data is true(Boolean)", () => {
     const result = deserialize.readData();
     expect(result).toEqual(true);
 });
+
+test("Deserialize data is false(Boolean)", () => {
+    const data = Buffer.from([0x01, 0x00]);
+    const deserialize = new AMF0Deserialize(data);
+    const result = deserialize.readData();
+    expect(result).toEqual(false);
+});
+
+
+test("Deserialize data is 'this is a テスト'(String)", () => {
+    const data = Buffer.from([0x02, 0x00, 0x13, 0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20,
+        0xE3, 0x83, 0x86, 0xE3, 0x82, 0xB9, 0xE3, 0x83, 0x88]);
+    const deserialize = new AMF0Deserialize(data);
+    const result = deserialize.readData();
+    expect(result).toEqual('this is a テスト');
+});
+
+
+test("Deserialize data is 'this is a 한글'(String)", () => {
+    const data = Buffer.from([0x02, 0x00, 0x13, 0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0xED, 0x95, 0x9C, 0xEA, 0xB8, 0x80]);
+    const deserialize = new AMF0Deserialize(data);
+    const result = deserialize.readData();
+    expect(result).toEqual('this is a 한글');
+});
+
+


### PR DESCRIPTION
- Task 
   test case(deserialized string case )
  
- 추가 확인 사항
@narumir 
> 아래 Test Case에서 실패합니다.  
   아마도 원인은 Buffer.alloc(len)에서 빈값으로  
   len 길이 만큼 초기화 하기 떄문인것 같습니다. 
   'this is a 한글' -> 이 문자열에 대한 hex 코드가 '74 68 69 73 20 69 73 20 61 20 ED 95 9C EA B8 80' 인데 
   실제로 코드 반환 되는 값은 '74 68 69 73 20 69 73 20 61 20 ED 95 9C EA B8 80 00 00 00' 이기 때문에 
   테스트에서 실패하는 것 같습니다.
  

```ts

private readStringMarker() {
        const len = this.readUInt16();
        const buf = Buffer.alloc(len);
        this.data.copy(buf, 0, this.cursor, this.cursor + len);
        this.cursor += len;
        return buf.toString();
}
```
 
![image](https://user-images.githubusercontent.com/11059706/172650724-79dd190d-a622-4724-b746-e508fb4e803a.png)
 
![image](https://user-images.githubusercontent.com/11059706/172647617-45b4d15c-7e6c-4caa-952a-2354bf7579f5.png)
