### PR TITLE
build: window os 일 경우 build 실패

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "start": "npm run build && node ./build/index.js",
-    "build": "babel src --out-dir build --extensions '.ts'"
+    "build": "babel src --out-dir build --extensions .ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- 빌드 실패로 package.json scripts 명령어 수정

- 원인 
  - Window os 일 경우 인자 따옴표 포함시 빌드 실패

  - 빌드 실패로 인한 수정 사항
    ```json
    // AS_IS
    "build": "babel src --out-dir build --extensions '.ts'"
    // TO_BE
    "build": "babel src --out-dir build --extensions .ts"
    
    ```